### PR TITLE
feat: add basic Next.js app with routes and middleware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.next
+out

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# chatgpt
+# ChatGPT Next.js Example
+
+This repository contains a minimal [Next.js](https://nextjs.org/) project with a couple of pages and a basic middleware.
+
+## Available Routes
+- `/` – Home page with a link to the About page.
+- `/about` – Simple static page.
+
+Requests to `/about` go through a middleware that adds an `x-powered-by` header.
+
+## Getting Started
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the development server:
+   ```bash
+   npm run dev
+   ```
+3. Build for production:
+   ```bash
+   npm run build
+   ```

--- a/middleware.js
+++ b/middleware.js
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server';
+
+export function middleware(request) {
+  const response = NextResponse.next();
+  response.headers.set('x-powered-by', 'middleware');
+  return response;
+}
+
+export const config = {
+  matcher: ['/about'],
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "chatgpt",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest"
+  }
+}

--- a/pages/about.js
+++ b/pages/about.js
@@ -1,0 +1,8 @@
+export default function About() {
+  return (
+    <main>
+      <h1>About Page</h1>
+      <p>This is a simple example page.</p>
+    </main>
+  );
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,0 +1,12 @@
+import Link from 'next/link';
+
+export default function Home() {
+  return (
+    <main>
+      <h1>Welcome to the Next.js sample app</h1>
+      <p>
+        Go to <Link href="/about">About page</Link>
+      </p>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- scaffold minimal Next.js project with sample pages
- add middleware that injects a custom header on /about requests
- document project setup and available routes

## Testing
- `npm test` (fails: no test specified)
- `npm run build` (fails: next: not found)

------
https://chatgpt.com/codex/tasks/task_e_6895d851c0048324a1461d22c5122042